### PR TITLE
os-2889 retry anchor link that was rejected by linter

### DIFF
--- a/pages/02.Documentation/02.compute/docs.de.md
+++ b/pages/02.Documentation/02.compute/docs.de.md
@@ -56,7 +56,7 @@ L1 4XLarge  | l1.4xlarge  | 256GB  |  64   | 1600GB   |
 
 (*)
 Der lokal angeschlossene Festspeicher kann ebenfalls durch unseren verteilten, langlebigen [Block-Speicher](../03.block-storage/docs.de.md) ergänzt werden,
-um weniger latenzkritische Daten dort zu speichern.
+[um weniger latenzkritische Daten dort zu speichern](../04.local-storage/docs.de.md#kann-local-ssd-storage-mit-distributed-storage-kombiniert-werden).
 
 
 ## Flavor change (resizing)

--- a/pages/02.Documentation/02.compute/docs.en.md
+++ b/pages/02.Documentation/02.compute/docs.en.md
@@ -56,7 +56,7 @@ L1 4XLarge  | l1.4xlarge  | 256GB  |  64   | 1600GB   |
 
 (*)
 You can extend local ephemeral storage using our distributed [Block Storage Service](../03.block-storage/docs.en.md),
-to place less latency critical data on it.
+[to place less latency critical data on it](../04.local-storage/docs.en.md#can-i-combine-local-ssd-storage-with-distributed-storage).
 
 
 ## Flavor change (resizing)


### PR DESCRIPTION
We had to unlink these two lines because the linter had problems with those very long links with their anchors. After an update of the linter, this should work now, hence the retry.