### PR TITLE
Document stack-manager API for quota/usage

### DIFF
--- a/pages/02.Tutorials/13.get-quota-info/docs.de.md
+++ b/pages/02.Tutorials/13.get-quota-info/docs.de.md
@@ -6,11 +6,12 @@ taxonomy:
         - docs
 ---
 
-# REST API zur Abfrage von Quota-Informationen
+## Einleitung
+
 Für die meisten Ressourcen-Typen wie z.B. Instanzen, VCPUs, Volume-Speicher
 können Sie die Limits und die aktuelle Auslastung über das Dashboard (Horizon)
 einsehen oder die OpenStack APIs nutzen, um die Informationen automatisiert
-abzufragen. Die Informationen über die Quota von Object-Storage (S3) sind 
+abzufragen. Die Informationen über die Quota von Object-Storage (S3) sind
 allerdings nicht über diese Standard-APIs verfügbar.
 
 Für Quota- und Ausnutzungsinformationen einschließlich Object-Storage bietet
@@ -22,7 +23,7 @@ Für Anfragen an die Quota-API benötigen Sie ein OpenStack-Keystone-Token.
 Wenn Sie den OpenStack-Kommandozeilen-Client installiert haben, können Sie
 sich ein Token mit dem Kommando `openstack token issue` erzeugen.
 
-```
+```plain
 openstack token issue
 +------------+----------------------------------+
 | Field      | Value                            |
@@ -33,13 +34,16 @@ openstack token issue
 | user_id    | 22222222222222222222222222222222 |
 +------------+----------------------------------+
 ```
+
 Das so erzeugte Token ("id"-Zeile in der Tabelle) geben Sie dann im `X-Auth-Token` der REST-API-Requests an.
 
 ## Quota abfrufen
 
 ### URL
 
+```plain
 GET https://api.cloud.syseleven.net:5001/v1/projects/{project_id}/quota
+```
 
 ### Anfrage-Parameter
 
@@ -55,14 +59,15 @@ Beispiel
 - Project-ID "11111111111111111111111111111111"
 - Regionen cbk und dbl
 
-```
+```shell
 curl -H 'X-Auth-Token: 01234567890abcdef01234567890abcd' https://api.cloud.syseleven.net:5001/v1/projects/11111111111111111111111111111111/quota?regions=cbk,dbl
 ```
 
 ### Antwort
 
 Die Antwort beinhaltet die Quota-Informationen in JSON-Format. Zum Beispiel bei einer Anfrage für die Regionen cbk und dbl:
-```
+
+```json
 {
   "cbk": {
     "compute.cores": 50,
@@ -106,6 +111,7 @@ Die Antwort beinhaltet die Quota-Informationen in JSON-Format. Zum Beispiel bei 
   }
 }
 ```
+
 Übersicht über die einzelnen Elemente:
 
 Name | Beschreibung
@@ -135,7 +141,9 @@ Ein Limit-Wert von -1 bedeutet "unbeschränkt", 0 bedeutet "keine Ressourcen".
 
 ### URL
 
+```plain
 GET https://api.cloud.syseleven.net:5001/v1/projects/{project_id}/current_usage
+```
 
 ### Anfrage-Parameter
 
@@ -151,14 +159,15 @@ Beispiel
 - Project-ID "11111111111111111111111111111111"
 - Regionen cbk und dbl
 
-```
+```shell
 curl -H 'X-Auth-Token: 01234567890abcdef01234567890abcd' https://api.cloud.syseleven.net:5001/v1/projects/11111111111111111111111111111111/current_usage?regions=cbk,dbl
 ```
 
 ### Antwort
+
 Die Antwort beinhaltet die Informationen über aktuell verwendete Ressourcen in JSON-Format. Zum Beispiel bei einer Anfrage für die Regionen cbk und dbl:
 
-```
+```json
 {
   "cbk": {
     "compute.cores": 3,

--- a/pages/02.Tutorials/13.get-quota-info/docs.de.md
+++ b/pages/02.Tutorials/13.get-quota-info/docs.de.md
@@ -14,7 +14,7 @@ einsehen oder die OpenStack APIs nutzen, um die Informationen automatisiert
 abzufragen. Die Informationen über die Quota von Object-Storage (S3) sind
 allerdings nicht über diese Standard-APIs verfügbar.
 
-Für Quota- und Ausnutzungsinformationen einschließlich Object-Storage bietet
+Für Quota- und Auslastungsinformationen einschließlich Object-Storage bietet
 der SysEleven Stack eine eigene REST API an.
 
 ## Voraussetzungen
@@ -137,7 +137,7 @@ volume.volumes | Anzahl der Block Storage Volumes |
 
 Ein Limit-Wert von -1 bedeutet "unbeschränkt", 0 bedeutet "keine Ressourcen".
 
-## Aktuelle Ausnutzung abfrufen
+## Aktuelle Auslastung abfrufen
 
 ### URL
 

--- a/pages/02.Tutorials/13.get-quota-info/docs.de.md
+++ b/pages/02.Tutorials/13.get-quota-info/docs.de.md
@@ -1,0 +1,234 @@
+---
+title: 'REST API für Quota-Informationen'
+date: '01-11-2019 12:00'
+taxonomy:
+    category:
+        - docs
+---
+
+# REST API zur Abfrage von Quota-Informationen
+Für die meisten Ressourcen-Typen wie z.B. Instanzen, VCPUs, Volume-Speicher
+können Sie die Limits und die aktuelle Auslastung über das Dashboard (Horizon)
+einsehen oder die OpenStack APIs nutzen, um die Informationen automatisiert
+abzufragen. Die Informationen über die Quota von Object-Storage (S3) sind 
+allerdings nicht über diese Standard-APIs verfügbar.
+
+Für Quota- und Ausnutzungsinformationen einschließlich Object-Storage bietet
+der SysEleven Stack eine eigene REST API an.
+
+## Voraussetzungen
+
+Für Anfragen an die Quota-API benötigen Sie ein OpenStack-Keystone-Token.
+Wenn Sie den OpenStack-Kommandozeilen-Client installiert haben, können Sie
+sich ein Token mit dem Kommando `openstack token issue` erzeugen.
+
+```
+openstack token issue
++------------+----------------------------------+
+| Field      | Value                            |
++------------+----------------------------------+
+| expires    | 2019-11-02T06:43:11+0000         |
+| id         | 01234567890abcdef01234567890abcd |
+| project_id | 11111111111111111111111111111111 |
+| user_id    | 22222222222222222222222222222222 |
++------------+----------------------------------+
+```
+Das so erzeugte Token ("id"-Zeile in der Tabelle) geben Sie dann im `X-Auth-Token` der REST-API-Requests an.
+
+## Quota abfrufen
+
+### URL
+
+GET https://api.cloud.syseleven.net:5001/v1/projects/{project_id}/quota
+
+### Anfrage-Parameter
+
+Name        | Wo übergeben | Beschreibung |
+------------|--------------|--------------|
+project_id  | URL-Pfad     | Die OpenStack Project-ID. Es muss die gleiche sein, für die das Token erstellt wurde. |
+X-Auth-Token | Header | Das Token zur Authorisierung der Anfrage. |
+regions      | URL-Parameter | Optionale Beschränkung der Abfrage auf bestimmte Regionen. Komma-separierte Liste von Regionsnamen. Ist keine Region angegeben, werden Daten über alle Regionen geliefert. |
+
+Beispiel
+
+- Token "01234567890abcdef01234567890abcd"
+- Project-ID "11111111111111111111111111111111"
+- Regionen cbk und dbl
+
+```
+curl -H 'X-Auth-Token: 01234567890abcdef01234567890abcd' https://api.cloud.syseleven.net:5001/v1/projects/11111111111111111111111111111111/quota?regions=cbk,dbl
+```
+
+### Antwort
+
+Die Antwort beinhaltet die Quota-Informationen in JSON-Format. Zum Beispiel bei einer Anfrage für die Regionen cbk und dbl:
+```
+{
+  "cbk": {
+    "compute.cores": 50,
+    "compute.instances": 50,
+    "compute.ram_mb": 204800,
+    "dns.zones": 10,
+    "network.floatingips": 50,
+    "network.lb_healthmonitors": 1024,
+    "network.lb_listeners": 1024,
+    "network.lb_members": 128,
+    "network.lb_pools": 128,
+    "network.loadbalancers": 1024,
+    "network.vpn_endpoint_groups": -1,
+    "network.vpn_ikepolicies": -1,
+    "network.vpn_ipsec_site_connections": -1,
+    "network.vpn_ipsecpolicies": -1,
+    "network.vpn_services": -1,
+    "s3.space_bytes": 4294967296,
+    "volume.space_gb": 1000,
+    "volume.volumes": 1024
+  },
+  "dbl": {
+    "compute.cores": 60,
+    "compute.instances": 60,
+    "compute.ram_mb": 245760,
+    "dns.zones": 10,
+    "network.floatingips": 50,
+    "network.lb_healthmonitors": 1024,
+    "network.lb_listeners": 1024,
+    "network.lb_members": 1024,
+    "network.lb_pools": 1024,
+    "network.loadbalancers": 1024,
+    "network.vpn_endpoint_groups": -1,
+    "network.vpn_ikepolicies": -1,
+    "network.vpn_ipsec_site_connections": -1,
+    "network.vpn_ipsecpolicies": -1,
+    "network.vpn_services": -1,
+    "s3.space_bytes": -1,
+    "volume.space_gb": 1000,
+    "volume.volumes": 1024
+  }
+}
+```
+Übersicht über die einzelnen Elemente:
+
+Name | Beschreibung
+-----|---------|-------------
+compute.cores | Anzahl der virtuellen Cores |
+compute.instances | Anzahl der virtuellen Maschinen (Server, Instanzen) |
+compute.ram_mb | RAM für virtuelle Maschinen in MB |
+dns.zones | Anzahl der DNS-Zonen |
+network.floatingips | Anzahl der Floating IP-Adressen |
+network.lb_healthmonitors | Anzahl der LBaaS Health-Monitors |
+network.lb_listeners | Anzahl der LBaaS Listener |
+network.lb_members | Anzahl der LBaaS Pool Member |
+network.lb_pools | Anzahl der LBaaS Pools |
+network.loadbalancers | Anzahl der LBaaS Load Balancer |
+network.vpn_endpoint_groups | Anzahl der VPNaaS Endpunktgruppen |
+network.vpn_ikepolicy | Anzahl der VPNaaS IKE Policies |
+network.vpn_ipsec_site_connections | Anzahl der VPNaaS Site Connections |
+network.vpn_ipsecpolicies | Anzahl der VPNaaS IPSec Policies |
+network.vpn_services | Anzahl der VPNaaS VPN-Dienste |
+s3.space_bytes | Limit des Object Storage (S3) Speichers in Bytes |
+volume.space_gb | Limit des Block Storage Speichers (für Volumes) in GB |
+volume.volumes | Anzahl der Block Storage Volumes |
+
+Ein Limit-Wert von -1 bedeutet "unbeschränkt", 0 bedeutet "keine Ressourcen".
+
+## Aktuelle Ausnutzung abfrufen
+
+### URL
+
+GET https://api.cloud.syseleven.net:5001/v1/projects/{project_id}/current_usage
+
+### Anfrage-Parameter
+
+Name        | Wo übergeben | Beschreibung |
+------------|--------------|--------------|
+project_id  | URL-Pfad     | Die OpenStack Project-ID. Es muss die gleiche sein, für die das Token erstellt wurde. |
+X-Auth-Token | Header | Das Token zur Authorisierung der Anfrage. |
+regions      | URL-Parameter | Optionale Beschränkung der Abfrage auf bestimmte Regionen. Komma-separierte Liste von Regionsnamen. Ist keine Region angegeben, werden Daten über alle Regionen geliefert. |
+
+Beispiel
+
+- Token "01234567890abcdef01234567890abcd"
+- Project-ID "11111111111111111111111111111111"
+- Regionen cbk und dbl
+
+```
+curl -H 'X-Auth-Token: 01234567890abcdef01234567890abcd' https://api.cloud.syseleven.net:5001/v1/projects/11111111111111111111111111111111/current_usage?regions=cbk,dbl
+```
+
+### Antwort
+Die Antwort beinhaltet die Informationen über aktuell verwendete Ressourcen in JSON-Format. Zum Beispiel bei einer Anfrage für die Regionen cbk und dbl:
+
+```
+{
+  "cbk": {
+    "compute.cores": 3,
+    "compute.flavors": {
+      "m1.micro": 3
+    },
+    "compute.instances": 3,
+    "compute.ram_mb": 6144,
+    "dns.zones": 2,
+    "network.floatingips": 4,
+    "network.lb_healthmonitors": 0,
+    "network.lb_listeners": 0,
+    "network.lb_members": 0,
+    "network.lb_pools": 0,
+    "network.loadbalancers": 0,
+    "network.vpn_endpoint_groups": 0,
+    "network.vpn_ikepolicies": 1,
+    "network.vpn_ipsec_site_connections": 1,
+    "network.vpn_ipsecpolicies": 1,
+    "network.vpn_services": 1,
+    "s3.space_bytes": 48,
+    "volume.space_gb": 6,
+    "volume.volumes": 4
+  },
+  "dbl": {
+    "compute.cores": 50,
+    "compute.flavors": {
+      "m1.medium": 5,
+      "m1.small": 3,
+      "m1.xxlarge": 1
+    },
+    "compute.instances": 9,
+    "compute.ram_mb": 204800,
+    "dns.zones": 2,
+    "network.floatingips": 10,
+    "network.lb_healthmonitors": 0,
+    "network.lb_listeners": 0,
+    "network.lb_members": 0,
+    "network.lb_pools": 0,
+    "network.loadbalancers": 0,
+    "network.vpn_endpoint_groups": 0,
+    "network.vpn_ikepolicies": 1,
+    "network.vpn_ipsec_site_connections": 1,
+    "network.vpn_ipsecpolicies": 1,
+    "network.vpn_services": 1,
+    "s3.space_bytes": 12,
+    "volume.space_gb": 133,
+    "volume.volumes": 7
+  }
+}
+```
+
+Name | Beschreibung
+-----|---------|-------------
+compute.cores | Anzahl der virtuellen Cores |
+compute.flavors | Anzahl der virtuellen Maschinen pro Flavor |
+compute.instances | Gesamtzahl der virtuellen Maschinen |
+compute.ram_mb | RAM aktuell laufender virtueller Maschinen in MB |
+dns.zones | Anzahl der DNS-Zonen |
+network.floatingips | Anzahl der Floating IP-Adressen |
+network.lb_healthmonitors | Anzahl der LBaaS Health-Monitors |
+network.lb_listeners | Anzahl der LBaaS Listener |
+network.lb_members | Anzahl der LBaaS Pool Member |
+network.lb_pools | Anzahl der LBaaS Pools |
+network.loadbalancers | Anzahl der LBaaS Load Balancer |
+network.vpn_endpoint_groups | Anzahl der VPNaaS Endpunktgruppen |
+network.vpn_ikepolicy | Anzahl der VPNaaS IKE Policies |
+network.vpn_ipsec_site_connections | Anzahl der VPNaaS Site Connections |
+network.vpn_ipsecpolicies | Anzahl der VPNaaS IPSec Policies |
+network.vpn_services | Anzahl der VPNaaS VPN-Dienste |
+s3.space_bytes | Aktuell belegter Speicher im Object Storage (S3) in Bytes |
+volume.space_gb | Aktuell belegter Speicher im Block Storage (Volumes) in GB |
+volume.volumes | Anzahl der Block Storage Volumes |

--- a/pages/02.Tutorials/13.get-quota-info/docs.en.md
+++ b/pages/02.Tutorials/13.get-quota-info/docs.en.md
@@ -1,0 +1,235 @@
+---
+title: 'REST API for Quota Information'
+date: '01-11-2019 12:00'
+taxonomy:
+    category:
+        - docs
+---
+
+# REST API to query quota and usage information
+For many resource types like instances, VCPUs, volume storage you can check
+the limits and the current usage in the dashboard (Horizon) or use the
+standard OpenStack APIs to collect the data in some automation.
+But information about quota and usage of object storage (S3) is not
+available using standard APIs.
+
+For quota and usage information including object storage the SysEleven Stack
+offers an own REST API.
+
+## Requirements
+
+For queries to the quota API you need an OpenStack Keystone token to
+authenticate with. If you installed the OpenStack command line tools
+you can create a token with the command `openstack token issue`.
+
+```
+openstack token issue
++------------+----------------------------------+
+| Field      | Value                            |
++------------+----------------------------------+
+| expires    | 2019-11-02T06:43:11+0000         |
+| id         | 01234567890abcdef01234567890abcd |
+| project_id | 11111111111111111111111111111111 |
+| user_id    | 22222222222222222222222222222222 |
++------------+----------------------------------+
+```
+The token ("id" row in the table) you will pass in the `X-Auth-Token` header of the REST API requests.
+
+## Query quota
+
+### URL
+
+GET https://api.cloud.syseleven.net:5001/v1/projects/{project_id}/quota
+
+### Request parameters
+
+Name        | Where    | Description |
+------------|----------|-------------|
+project_id  | URL path | The OpenStack project ID. It needs to be the same as the one the token was created with. |
+X-Auth-Token | Header | Token for authenticating the request. |
+regions      | URL query parameter | Optionally restrict the regions to be queried. Comma-separated list of region names. If no region is given here, all regions are queried. |
+
+Example
+
+- Token "01234567890abcdef01234567890abcd"
+- Project ID "11111111111111111111111111111111"
+- Regions cbk and dbl
+
+```
+curl -H 'X-Auth-Token: 01234567890abcdef01234567890abcd' https://api.cloud.syseleven.net:5001/v1/projects/11111111111111111111111111111111/quota?regions=cbk,dbl
+```
+
+### Response
+
+The response contains the quota information in JSON format. Example for a response with information about regions cbk and dbl:
+
+```
+{
+  "cbk": {
+    "compute.cores": 50,
+    "compute.instances": 50,
+    "compute.ram_mb": 204800,
+    "dns.zones": 10,
+    "network.floatingips": 50,
+    "network.lb_healthmonitors": 1024,
+    "network.lb_listeners": 1024,
+    "network.lb_members": 128,
+    "network.lb_pools": 128,
+    "network.loadbalancers": 1024,
+    "network.vpn_endpoint_groups": -1,
+    "network.vpn_ikepolicies": -1,
+    "network.vpn_ipsec_site_connections": -1,
+    "network.vpn_ipsecpolicies": -1,
+    "network.vpn_services": -1,
+    "s3.space_bytes": 4294967296,
+    "volume.space_gb": 1000,
+    "volume.volumes": 1024
+  },
+  "dbl": {
+    "compute.cores": 60,
+    "compute.instances": 60,
+    "compute.ram_mb": 245760,
+    "dns.zones": 10,
+    "network.floatingips": 50,
+    "network.lb_healthmonitors": 1024,
+    "network.lb_listeners": 1024,
+    "network.lb_members": 1024,
+    "network.lb_pools": 1024,
+    "network.loadbalancers": 1024,
+    "network.vpn_endpoint_groups": -1,
+    "network.vpn_ikepolicies": -1,
+    "network.vpn_ipsec_site_connections": -1,
+    "network.vpn_ipsecpolicies": -1,
+    "network.vpn_services": -1,
+    "s3.space_bytes": -1,
+    "volume.space_gb": 1000,
+    "volume.volumes": 1024
+  }
+}
+```
+Overview of fields:
+
+Name | Beschreibung
+-----|---------|-------------
+compute.cores | Number of virtual cores |
+compute.instances | Number of virtual machines (servers, instances) |
+compute.ram_mb | RAM for virtual machines in MB |
+dns.zones | Number of DNS zones |
+network.floatingips | Number of floating IP addresses |
+network.lb_healthmonitors | Number of LBaaS health monitors |
+network.lb_listeners | Number of LBaaS listeners |
+network.lb_members | Number of LBaaS pool members |
+network.lb_pools | Number of LBaaS pools |
+network.loadbalancers | Number of LBaaS load balancers |
+network.vpn_endpoint_groups | Number of VPNaaS endpoint groups |
+network.vpn_ikepolicy | Number of VPNaaS IKE policies |
+network.vpn_ipsec_site_connections | Number of VPNaaS site connections |
+network.vpn_ipsecpolicies | Number of VPNaaS IPSec policies |
+network.vpn_services | Number of VPNaaS VPN services |
+s3.space_bytes | Limit of Object Storage (S3) size in bytes |
+volume.space_gb | Limit of Block Storage size (for volumes) in GB |
+volume.volumes | Number of Block Storage volumes |
+
+A limit of -1 means "unlimited", 0 means "no resources".
+
+## Query current usage
+
+### URL
+
+GET https://api.cloud.syseleven.net:5001/v1/projects/{project_id}/current_usage
+
+### Request parameters
+
+Name        | Where    | Description |
+------------|----------|-------------|
+project_id  | URL path | The OpenStack project ID. It needs to be the same as the one the token was created with. |
+X-Auth-Token | Header | Token for authenticating the request. |
+regions      | URL query parameter | Optionally restrict the regions to be queried. Comma-separated list of region names. If no region is given here, all regions are queried. |
+
+Example
+
+- Token "01234567890abcdef01234567890abcd"
+- Project ID "11111111111111111111111111111111"
+- Regions cbk and dbl
+
+```
+curl -H 'X-Auth-Token: 01234567890abcdef01234567890abcd' https://api.cloud.syseleven.net:5001/v1/projects/11111111111111111111111111111111/current_usage?regions=cbk,dbl
+```
+
+### Response
+The response contains the information about the currently-used resources in JSON format. Example of a response with data about regions cbk and dbl:
+
+```
+{
+  "cbk": {
+    "compute.cores": 3,
+    "compute.flavors": {
+      "m1.micro": 3
+    },
+    "compute.instances": 3,
+    "compute.ram_mb": 6144,
+    "dns.zones": 2,
+    "network.floatingips": 4,
+    "network.lb_healthmonitors": 0,
+    "network.lb_listeners": 0,
+    "network.lb_members": 0,
+    "network.lb_pools": 0,
+    "network.loadbalancers": 0,
+    "network.vpn_endpoint_groups": 0,
+    "network.vpn_ikepolicies": 1,
+    "network.vpn_ipsec_site_connections": 1,
+    "network.vpn_ipsecpolicies": 1,
+    "network.vpn_services": 1,
+    "s3.space_bytes": 48,
+    "volume.space_gb": 6,
+    "volume.volumes": 4
+  },
+  "dbl": {
+    "compute.cores": 50,
+    "compute.flavors": {
+      "m1.medium": 5,
+      "m1.small": 3,
+      "m1.xxlarge": 1
+    },
+    "compute.instances": 9,
+    "compute.ram_mb": 204800,
+    "dns.zones": 2,
+    "network.floatingips": 10,
+    "network.lb_healthmonitors": 0,
+    "network.lb_listeners": 0,
+    "network.lb_members": 0,
+    "network.lb_pools": 0,
+    "network.loadbalancers": 0,
+    "network.vpn_endpoint_groups": 0,
+    "network.vpn_ikepolicies": 1,
+    "network.vpn_ipsec_site_connections": 1,
+    "network.vpn_ipsecpolicies": 1,
+    "network.vpn_services": 1,
+    "s3.space_bytes": 12,
+    "volume.space_gb": 133,
+    "volume.volumes": 7
+  }
+}
+```
+
+Name | Beschreibung
+-----|---------|-------------
+compute.cores | Number of virtual cores |
+compute.flavors | Number of virtual machines per flavor |
+compute.instances | Total number of virtual machines |
+compute.ram_mb | Total RAM of virtual machines in MB |
+dns.zones | Number of DNS zones |
+network.floatingips | Number of floating IP addresses |
+network.lb_healthmonitors | Number of LBaaS health monitors |
+network.lb_listeners | Number of LBaaS listeners |
+network.lb_members | Number of LBaaS pool members |
+network.lb_pools | Number of LBaaS pools |
+network.loadbalancers | Number of LBaaS load balancers |
+network.vpn_endpoint_groups | Number of VPNaaS endpoint groups |
+network.vpn_ikepolicy | Number of VPNaaS IKE policies |
+network.vpn_ipsec_site_connections | Number of VPNaaS site connections |
+network.vpn_ipsecpolicies | Number of VPNaaS IPSec policies |
+network.vpn_services | Number of VPNaaS VPN services |
+s3.space_bytes | Used size of Object Storage (S3) in Bytes |
+volume.space_gb | Used size of Block Storage (volumes) in GB |
+volume.volumes | Number of Block Storage volumes |

--- a/pages/02.Tutorials/13.get-quota-info/docs.en.md
+++ b/pages/02.Tutorials/13.get-quota-info/docs.en.md
@@ -114,7 +114,7 @@ The response contains the quota information in JSON format. Example for a respon
 
 Overview of fields:
 
-Name | Beschreibung
+Field | Description
 -----|---------|-------------
 compute.cores | Number of virtual cores |
 compute.instances | Number of virtual machines (servers, instances) |
@@ -220,7 +220,7 @@ The response contains the information about the currently-used resources in JSON
 }
 ```
 
-Name | Beschreibung
+Field | Description
 -----|---------|-------------
 compute.cores | Number of virtual cores |
 compute.flavors | Number of virtual machines per flavor |

--- a/pages/02.Tutorials/13.get-quota-info/docs.en.md
+++ b/pages/02.Tutorials/13.get-quota-info/docs.en.md
@@ -6,7 +6,8 @@ taxonomy:
         - docs
 ---
 
-# REST API to query quota and usage information
+## Introduction
+
 For many resource types like instances, VCPUs, volume storage you can check
 the limits and the current usage in the dashboard (Horizon) or use the
 standard OpenStack APIs to collect the data in some automation.
@@ -22,7 +23,7 @@ For queries to the quota API you need an OpenStack Keystone token to
 authenticate with. If you installed the OpenStack command line tools
 you can create a token with the command `openstack token issue`.
 
-```
+```plain
 openstack token issue
 +------------+----------------------------------+
 | Field      | Value                            |
@@ -33,13 +34,16 @@ openstack token issue
 | user_id    | 22222222222222222222222222222222 |
 +------------+----------------------------------+
 ```
+
 The token ("id" row in the table) you will pass in the `X-Auth-Token` header of the REST API requests.
 
 ## Query quota
 
 ### URL
 
+```plain
 GET https://api.cloud.syseleven.net:5001/v1/projects/{project_id}/quota
+```
 
 ### Request parameters
 
@@ -55,7 +59,7 @@ Example
 - Project ID "11111111111111111111111111111111"
 - Regions cbk and dbl
 
-```
+```shell
 curl -H 'X-Auth-Token: 01234567890abcdef01234567890abcd' https://api.cloud.syseleven.net:5001/v1/projects/11111111111111111111111111111111/quota?regions=cbk,dbl
 ```
 
@@ -63,7 +67,7 @@ curl -H 'X-Auth-Token: 01234567890abcdef01234567890abcd' https://api.cloud.sysel
 
 The response contains the quota information in JSON format. Example for a response with information about regions cbk and dbl:
 
-```
+```json
 {
   "cbk": {
     "compute.cores": 50,
@@ -107,6 +111,7 @@ The response contains the quota information in JSON format. Example for a respon
   }
 }
 ```
+
 Overview of fields:
 
 Name | Beschreibung
@@ -136,7 +141,9 @@ A limit of -1 means "unlimited", 0 means "no resources".
 
 ### URL
 
+```plain
 GET https://api.cloud.syseleven.net:5001/v1/projects/{project_id}/current_usage
+```
 
 ### Request parameters
 
@@ -152,14 +159,15 @@ Example
 - Project ID "11111111111111111111111111111111"
 - Regions cbk and dbl
 
-```
+```shell
 curl -H 'X-Auth-Token: 01234567890abcdef01234567890abcd' https://api.cloud.syseleven.net:5001/v1/projects/11111111111111111111111111111111/current_usage?regions=cbk,dbl
 ```
 
 ### Response
+
 The response contains the information about the currently-used resources in JSON format. Example of a response with data about regions cbk and dbl:
 
-```
+```json
 {
   "cbk": {
     "compute.cores": 3,


### PR DESCRIPTION
(only merge after stack-manager update is rolled out)

Document the 2 stack-manager API endpoints that allow to get quota and usage information per project.