### PR TITLE
Fix VPNaaS doc: remove sha384, sha512 from list

### DIFF
--- a/user/pages/04.Reference/08.network/docs.en.md
+++ b/user/pages/04.Reference/08.network/docs.en.md
@@ -96,8 +96,6 @@ Currently our VPNaaS implementation supports the following algorithms in both ph
 | -------------- |
 | SHA-1          |
 | SHA-256        |
-| SHA-384        |
-| SHA-512        |
 
 | Encryption     |
 | -------------- |


### PR DESCRIPTION
The auth algorithms sha384 and sha512 are currently rejected by
the neutron-vpnaas plugin. Removed them from the list of supported
algorithms.