### PR TITLE
Add SHA-384 and SHA-512

### DIFF
--- a/user/pages/04.Reference/08.network/docs.en.md
+++ b/user/pages/04.Reference/08.network/docs.en.md
@@ -96,6 +96,8 @@ Currently our VPNaaS implementation supports the following algorithms in both ph
 | -------------- |
 | SHA-1          |
 | SHA-256        |
+| SHA-384        |
+| SHA-512        |
 
 | Encryption     |
 | -------------- |


### PR DESCRIPTION
Add sha-384 and sha-512 as supported VPNaaS auth algorithms again
(after neutron-vpnaas was fixed to not reject them)