### PR TITLE
Document limit of number of members in octavia LB

### DIFF
--- a/user/pages/04.Reference/08.network/02.lbaas/docs.en.md
+++ b/user/pages/04.Reference/08.network/02.lbaas/docs.en.md
@@ -175,3 +175,7 @@ The default load balancer flavor is `failover-small` which offers more performan
 ### Connection Limit
 
 By default the Octavia load balancers are configured with a connection limit of 50000. You may set a different limit in the configuration of the listener.
+
+### Topology limits
+
+The total number of members (backends) across all pools of a load balancer is limited to 300.


### PR DESCRIPTION
If the number of members/backends of an octavia LB exceeds 300 the
UDP packet with the health update sent by the amphora may not reach
the health manager and that will lead to unnecessary failovers.