### PR TITLE
fixed repo version of grav

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.code.syseleven.de/syseleven/managed-services/docs/grav-docker:2021-01-18-154435
+FROM registry.code.syseleven.de/syseleven/managed-services/docs/grav-docker:2021-03-15-212549
 
 # We need the page to be at /var/www/html/metakube for easier ingress configuration
 USER root


### PR DESCRIPTION
as docker compose was not working with the old repo version inside the Dockerfile this Dockerfile with the fixed registry url the docker-compose build setups up the local grav appropriatly 