### PR TITLE
add-ec2-credential-warning

### DIFF
--- a/user/pages/04.Reference/05.object-storage/docs.en.md
+++ b/user/pages/04.Reference/05.object-storage/docs.en.md
@@ -89,7 +89,7 @@ openstack ec2 credentials list
 !! **Important note**
 !! Since the authentication service is centralised, the credentials created have access to SEOS/S3 in all regions.
 !! Access to a specific region is gained by defining different storage backend URLs.
-!! The credentials can also be used "backwards" to create a token for the user owning the credentials, thus with the access/secret key pair it is possible to gain access to OpenStack resources.
+!! EC2 credentials are not restricted to use on SEOS/S3 resources, they can also be used to create a token for the user owning the credentials, thus providing full access to all OpenStack resources that the user that created the EC2 credentials has access to. This is not a privilege escalation, it is (although probably unexpectedly) designed that way. Handle your EC2 credentials with the same caution as your OpenStack credentials.
 
 
 ## Clients

--- a/user/pages/04.Reference/05.object-storage/docs.en.md
+++ b/user/pages/04.Reference/05.object-storage/docs.en.md
@@ -89,6 +89,7 @@ openstack ec2 credentials list
 !! **Important note**
 !! Since the authentication service is centralised, the credentials created have access to SEOS/S3 in all regions.
 !! Access to a specific region is gained by defining different storage backend URLs.
+!! The credentials can also be used "backwards" to create a token for the user owning the credentials, thus with the access/secret key pair it is possible to gain access to OpenStack resources.
 
 
 ## Clients


### PR DESCRIPTION
Adding another note to the important notes that ec2 credentials can also be used "backwards" so that you can create a Keystone token for the user is owning the credentials.

os-8910