### PR TITLE
Drop support for German language

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM registry.code.syseleven.de/syseleven/managed-services/docs/grav-docker:2021
 
 # We need the page to be at /var/www/html/metakube for easier ingress configuration
 USER root
-RUN mv /var/www/html /tmp/syseleven-stack && mkdir /var/www/html && mv /tmp/syseleven-stack /var/www/html/syseleven-stack
+RUN mv /var/www/html /tmp/syseleven-stack && mkdir /var/www/html && mv /tmp/syseleven-stack /var/www/html/syseleven-stack && chown www-data:www-data /var/www/html
 USER www-data
 
 COPY --chown=www-data:www-data user/config syseleven-stack/user/config
 COPY --chown=www-data:www-data user/pages syseleven-stack/user/pages
-
+COPY --chown=www-data:www-data user/apache2/.htaccess .

--- a/README.md
+++ b/README.md
@@ -44,3 +44,19 @@ docker-compose up --build
 Then open http://localhost:8080/syseleven-stack in your browser. **Grav is caching very aggressively, if you don’t see changes made, reload without cache.
 
 **Important: If you make changes to the content, you have to execute the command again as all content is built into the image statically**
+
+## Multi-language support
+
+Available documentation languages can be configured in [`user/config/system.yaml`](user/config/system.yaml).
+
+Markdown files must be at least available in English language; If a translation is not available grav will
+fall back to English language.
+
+At the moment (Dec 2021) we only support English language documentation. As we used to have German language docs
+as well, the German links (/de) are redirected to English pages (/en) for SEO and UX reasons.
+In production this permanent redirect is implemented outside of this repository.
+
+For the docker image to test with we implemented a `RedirectMatch` rule in an additional [`.htaccess`](user/apache2/.htaccess) file. 
+We deploy the .htaccess file in the [`Dockerfile`](Dockerfile) using `COPY`. Please note that there is another
+`.htaccess` file in `/var/www/html/syseleven-stack/` from the parent container; statements there will take precedence.
+For that reason you cannot use `Rewrite` rules unfortunately.

--- a/user/apache2/.htaccess
+++ b/user/apache2/.htaccess
@@ -1,0 +1,12 @@
+# NOTE: Currently we do not support german language documentation. We used to have it, and therefore
+# we implement a permanent redirect here to the english documentation of SysEleven Stack for SEO and UX reasons.
+# See also README for more information on internationalization support in the docs.
+RedirectMatch 301 ^/syseleven-stack/de(/.*)?$ /syseleven-stack/en$1
+
+# Disable PHP error logging to the web site
+php_flag display_startup_errors off
+php_flag display_errors off
+php_flag html_errors off
+# As we are running in a docker container, let's log warnings and errors to stderr
+php_flag log_errors on
+php_value error_log /dev/stderr

--- a/user/config/system.yaml
+++ b/user/config/system.yaml
@@ -8,7 +8,6 @@ intl_enabled: true
 languages:
   supported:
     - en
-    - de
   include_default_lang: true
   translations: true
   translations_fallback: true


### PR DESCRIPTION
In test container there is now a permanent redirect from /de to /en pages.
In production that redirect needs to be configured outside of this repo.