### PR TITLE
fix broken links

### DIFF
--- a/user/pages/03.Howtos/05.nova-rescue-mode/docs.en.md
+++ b/user/pages/03.Howtos/05.nova-rescue-mode/docs.en.md
@@ -50,7 +50,7 @@ ssh syseleven@<server-ip>
 The following commands need to be executed in the ssh session.
 
 We also need the OpenStack credentials (openrc-file).
-You can download the file [here](https://cloud.syseleven.de/horizon/project/access_and_security/api_access/openrc/).
+You can download the file [here](https://cloud.syseleven.de/horizon/project/api_access/openrc/).
 
 ```shell
 source openrc

--- a/user/pages/03.Howtos/07.upload-images/docs.en.md
+++ b/user/pages/03.Howtos/07.upload-images/docs.en.md
@@ -49,7 +49,7 @@ resources:
       location: https://cdimage.debian.org/cdimage/openstack/current-9/debian-9-openstack-amd64.qcow2
 ```
 
-Further information can be found [here](https://cloud.syseleven.de/horizon/project/stacks/resource_types/OS::Glance::Image).
+Further information can be found [here](https://cloud.syseleven.de/horizon/project/resource_types/OS::Glance::Image/).
 
 ## Image sources
 


### PR DESCRIPTION
It seems with an update to horizon some links in our documentation got broken.
os-11140