### PR TITLE
Deprecate VPNaaS DH Group 2

### DIFF
--- a/user/pages/04.Reference/08.network/docs.en.md
+++ b/user/pages/04.Reference/08.network/docs.en.md
@@ -100,9 +100,12 @@ Currently our VPNaaS implementation supports the following algorithms in both ph
 
 | DH Groups      |
 | -------------- |
-| Group 2        |
 | Group 5        |
 | Group 14       |
+
+!! **Deprecation warning**
+!! DH Group 2 is not supported anymore.
+!! API requests to setup policies using DH Group 2 will be rejected.
 
 See our terraform examples on GitHub [for an example how to connect two regions using VPNaaS](https://github.com/syseleven/terraform-examples/tree/master/vpnaas).
 


### PR DESCRIPTION
Remove DH Group 2 from VPNaaS algorithm list. Add deprecation warning for DH group 2.
Related internal ticket : os-12788