### PR TITLE
Remove stack-manager project limitation

### DIFF
--- a/user/pages/04.Reference/10.get-quota-info/docs.en.md
+++ b/user/pages/04.Reference/10.get-quota-info/docs.en.md
@@ -38,12 +38,6 @@ With the following command you may directly assign a new token to a shell variab
 token=$(openstack token issue -c id -f value)
 ```
 
-### Known limitations
-
-!! Due to implementation issues, the API is currently limited to return data about the default project of a user. Queries about other accessible projects will fail.
-
-Until we are able to fix this issue, we provide our customers having multiple openstack projects with additional credentials for each project.
-
 ### API versions
 
 There are 2 versions of the API: v1 and v2. Version v2 extends the data schema for usage and quota API endpoints to add values related to Octavia load balancers. The following examples use v2-based URLs, but v1 is still supported (just replace v2 with v1 in the URL).


### PR DESCRIPTION
Queries to s11stack-manager now work with non-default project too.