### PR TITLE
Update glance image create howto section

### DIFF
--- a/user/pages/03.Howtos/07.upload-images/docs.en.md
+++ b/user/pages/03.Howtos/07.upload-images/docs.en.md
@@ -21,35 +21,13 @@ There are three different ways to upload custom images.
 ### OpenStack-CLI
 
 You need to have the [OpenStack-CLI](../../03.Howtos/02.openstack-cli/docs.en.md) installed and configured.
+Download an image you want to use, e.g. an [Ubuntu cloud image](https://cloud-images.ubuntu.com).
 After [sourcing the openrc.sh](../../02.Tutorials/02.api-access/docs.en.md) you can easily upload your own image and use it right after, like this:
 
 ```shell
-glance --os-image-api-version 1 image-create --progress --is-public False --disk-format=qcow2 \
---container-format=bare --property architecture=x86_64 --name="Debian Stretch" \
---location https://cdimage.debian.org/cdimage/openstack/current-9/debian-9-openstack-amd64.qcow2
+openstack image create --progress --private --disk-format=qcow2 --container-format=bare \
+--property architecture=x86_64 --name="Ubuntu Noble" --file noble-server-cloudimg-amd64.img
 ```
-
-### Heat-Template
-
-It is also possible to upload images with heat.
-An example can look like this:
-
-```yaml
-heat_template_version: 2016-04-08
-
-description: Simple template to upload an image
-
-resources:
-  glance_image:
-    type: OS::Glance::Image
-    properties:
-      container_format: bare
-      disk_format: qcow2
-      name: Debian Stretch
-      location: https://cdimage.debian.org/cdimage/openstack/current-9/debian-9-openstack-amd64.qcow2
-```
-
-Further information can be found [here](https://cloud.syseleven.de/horizon/project/resource_types/OS::Glance::Image/).
 
 ## Image sources
 


### PR DESCRIPTION
Updating the Glance image upload howto section. We should be using the general OpenStack client instead of Glance directly. Further the upload via URL might get disabled in the future. Heat does not support using a local file, thus we remove this section completely.