### PR TITLE
os-21032 deprecate quobyte and make ceph default in fes

### DIFF
--- a/user/pages/04.Reference/03.compute/docs.en.md
+++ b/user/pages/04.Reference/03.compute/docs.en.md
@@ -24,53 +24,55 @@ Disk data will be distributed across multiple servers (SysEleven Distributed Sto
 
 We recommend these instance types for most workloads and applications.
 
+!! `m1*`-flavors will be end-of-life in our Region `fes` on 2025-06-15. We recommend to use `m2*`-flavors instead. For existing intances refer to our [migration howto](../../03.Howtos/16.migrate-quobyte-to-ceph/docs.en.md).
+
 #### Balanced
 
 Name        | API Name    | Memory | vCPUs | Storage* | Region availability  |
 ------------|-------------|--------|-------|----------|----------------------|
-M1 Tiny     |  m1.tiny    |  4GiB  |   1   |   50GiB  | dbl, cbk, fes        |
+M1 Tiny     |  m1.tiny    |  4GiB  |   1   |   50GiB  | dbl, cbk (fes eol 2025-06-15) |
 M2 Tiny     |  m2.tiny    |  4GiB  |   1   |   50GiB  | fes                  |
-M1 Small    |  m1.small   |  8GiB  |   2   |   50GiB  | dbl, cbk, fes        |
+M1 Small    |  m1.small   |  8GiB  |   2   |   50GiB  | dbl, cbk (fes eol 2025-06-15) |
 M2 Small    |  m2.small   |  8GiB  |   2   |   50GiB  | fes                  |
-M1 Medium   |  m1.medium  | 16GiB  |   4   |   50GiB  | dbl, cbk, fes        |
+M1 Medium   |  m1.medium  | 16GiB  |   4   |   50GiB  | dbl, cbk (fes eol 2025-06-15) |
 M2 Medium   |  m2.medium  | 16GiB  |   4   |   50GiB  | fes                  |
-M1 Large    |  m1.large   | 32GiB  |   8   |   50GiB  | dbl, cbk, fes        |
+M1 Large    |  m1.large   | 32GiB  |   8   |   50GiB  | dbl, cbk (fes eol 2025-06-15) |
 M2 Large    |  m2.large   | 32GiB  |   8   |   50GiB  | fes                  |
-(M1 XLarge)\*\*   |  (m1.xlarge)\*\* | 64GiB   |   16   |   50GiB   | dbl, cbk, fes |
+(M1 XLarge)\*\*   |  (m1.xlarge)\*\* | 64GiB   |   16   |   50GiB   | dbl, cbk (fes eol 2025-06-15) |
 (M2 XLarge)\*\*   |  (m2.xlarge)\*\* | 64GiB   |   16   |   50GiB   | fes           |
-(M1 XXLarge)\*\*  |  (m1.xxlarge)\*\* | 128GiB|   32   |   50GiB   | dbl, cbk, fes |
+(M1 XXLarge)\*\*  |  (m1.xxlarge)\*\* | 128GiB|   32   |   50GiB   | dbl, cbk (fes eol 2025-06-15) |
 (M2 XXLarge)\*\*  |  (m1.xxlarge)\*\* | 128GiB|   32   |   50GiB   | fes           |
 
 #### CPU optimized
 
 Name            | API Name     | Memory  | vCPUs | Storage*  | Region availability  |
 ----------------|--------------|---------|-------|-----------|----------------------|
-M1 CPU Tiny     |  m1c.tiny    |  2GiB   |   1   |   50GiB   | dbl, cbk, fes        |
+M1 CPU Tiny     |  m1c.tiny    |  2GiB   |   1   |   50GiB   | dbl, cbk (fes eol 2025-06-15) |
 M2 CPU Tiny     |  m2c.tiny    |  2GiB   |   1   |   50GiB   | fes                  |
-M1 CPU Small    |  m1c.small   |  4GiB   |   2   |   50GiB   | dbl, cbk, fes        |
+M1 CPU Small    |  m1c.small   |  4GiB   |   2   |   50GiB   | dbl, cbk (fes eol 2025-06-15) |
 M2 CPU Small    |  m2c.small   |  4GiB   |   2   |   50GiB   | fes                  |
-M1 CPU Medium   |  m1c.medium  | 8GiB    |   4   |   50GiB   | dbl, cbk, fes        |
+M1 CPU Medium   |  m1c.medium  | 8GiB    |   4   |   50GiB   | dbl, cbk (fes eol 2025-06-15) |
 M2 CPU Medium   |  m2c.medium  | 8GiB    |   4   |   50GiB   | fes                  |
-M1 CPU Large    |  m1c.large   | 16GiB   |   8   |   50GiB   | dbl, cbk, fes        |
+M1 CPU Large    |  m1c.large   | 16GiB   |   8   |   50GiB   | dbl, cbk (fes eol 2025-06-15) |
 M2 CPU Large    |  m2c.large   | 16GiB   |   8   |   50GiB   | fes                  |
-M1 CPU XLarge   |  m1c.xlarge  | 32GiB   |   16  |   50GiB   | dbl, cbk, fes        |
+M1 CPU XLarge   |  m1c.xlarge  | 32GiB   |   16  |   50GiB   | dbl, cbk (fes eol 2025-06-15) |
 M2 CPU XLarge   |  m2c.xlarge  | 32GiB   |   16  |   50GiB   | fes                  |
-(M1 CPU XXLarge)\*\* |  (m1c.xxlarge)\*\* | 64GiB   |   32   |   50GiB   | dbl, cbk, fes |
+(M1 CPU XXLarge)\*\* |  (m1c.xxlarge)\*\* | 64GiB   |   32   |   50GiB   | dbl, cbk (fes eol 2025-06-15) |
 (M2 CPU XXLarge)\*\* |  (m2c.xxlarge)\*\* | 64GiB   |   32   |   50GiB   | fes           |
 
 #### RAM optimized
 
 Name            | API Name     | Memory  | vCPUs | Storage* | Region availability  |
 ----------------|--------------|---------|-------|----------|----------------------|
-M1 RAM Tiny     |  m1r.tiny    |  8GiB   |   1   |   50GiB  | dbl, cbk, fes        |
+M1 RAM Tiny     |  m1r.tiny    |  8GiB   |   1   |   50GiB  | dbl, cbk (fes eol 2025-06-15) |
 M2 RAM Tiny     |  m2r.tiny    |  8GiB   |   1   |   50GiB  | fes                  |
-M1 RAM Small    |  m1r.small   | 16GiB   |   2   |   50GiB  | dbl, cbk, fes        |
+M1 RAM Small    |  m1r.small   | 16GiB   |   2   |   50GiB  | dbl, cbk (fes eol 2025-06-15) |
 M2 RAM Small    |  m2r.small   | 16GiB   |   2   |   50GiB  | fes                  |
-M1 RAM Medium   |  m1r.medium  | 32GiB   |   4   |   50GiB  | dbl, cbk, fes        |
+M1 RAM Medium   |  m1r.medium  | 32GiB   |   4   |   50GiB  | dbl, cbk (fes eol 2025-06-15) |
 M2 RAM Medium   |  m2r.medium  | 32GiB   |   4   |   50GiB  | fes                  |
-(M1 RAM Large)\*\*  |  (m1r.large)\*\* | 64GiB   |   8   |   50GiB   | dbl, cbk, fes |
+(M1 RAM Large)\*\*  |  (m1r.large)\*\* | 64GiB   |   8   |   50GiB   | dbl, cbk (fes eol 2025-06-15) |
 (M2 RAM Large)\*\*  |  (m2r.large)\*\* | 64GiB   |   8   |   50GiB   | fes             |
-(M1 RAM XLarge)\*\* |  (m1r.xlarge)\*\* | 128GiB  |   16   |   50GiB   | dbl, cbk, fes |
+(M1 RAM XLarge)\*\* |  (m1r.xlarge)\*\* | 128GiB  |   16   |   50GiB   | dbl, cbk (fes eol 2025-06-15) |
 (M2 RAM XLarge)\*\* |  (m2r.xlarge)\*\* | 128GiB  |   16   |   50GiB   | fes           |
 
 (*)

--- a/user/pages/04.Reference/04.block-storage/docs.en.md
+++ b/user/pages/04.Reference/04.block-storage/docs.en.md
@@ -19,15 +19,17 @@ You can manage your block storage volumes and make them available to your comput
 
 | Volume type                             | CBK region    | DBL region    | FES region
 | ----------------------------------------|---------------|---------------|-----------
-| quobyte                                 | Yes (default) | Yes (default) | Yes (default)
-| quobyte-multiattach                     | Yes           | Yes           | Yes
-| ceph                                    | No            | No            | Yes
+| quobyte                                 | Yes (default) | Yes (default) | Yes (eol 2025-06-15)
+| quobyte-multiattach                     | Yes           | Yes           | Yes (eol 2025-06-15)
+| ceph                                    | No            | No            | Yes (default)
 
 ### quobyte
 
 The data will be stored on SSDs in the SysEleven Stack distributed storage cluster based on Quobyte. The data will be replicated and stored on three different storage nodes and SSDs.
 
 A volume can only be attached to a single virtual machine at a time.
+
+!! This storage type will be end-of-life in our Region `fes` on 2025-06-15. We recommend to use `ceph` instead. For existing Volumes refer to our [migration howto](../../03.Howtos/16.migrate-quobyte-to-ceph/docs.en.md).
 
 ### quobyte-multiattach
 
@@ -38,6 +40,8 @@ The performance of `quobyte-multiattach` is slightly reduced because some cachin
 Please refer to our multi-attach volume tutorial. It explains [how to use multi-attach volumes with the cluster file system ocfs2](../../02.Tutorials/10.cinder-multiattach/docs.en.md).
 
 !! WARNING: This mode of operation requires special cluster file systems like ocfs2 or gfs2. Otherwise it can lead to the loss of data and/or file system and data corruption.
+
+!! This storage type will be end-of-life in our Region `fes` on 2025-06-15. Due to negligible use we haven't decided on a general alternative yet. I you rely on this feature in this region, please contact the [Support at support@syseleven.de](../../06.Support/default.en.md).
 
 ### ceph
 

--- a/user/pages/04.Reference/05.object-storage/docs.en.md
+++ b/user/pages/04.Reference/05.object-storage/docs.en.md
@@ -63,12 +63,14 @@ Region   | URL                                    | Backend             |
 ---------|----------------------------------------|---------------------|
 CBK      | s3.cbk.cloud.syseleven.net             | Quobyte             |
 DBL      | s3.dbl.cloud.syseleven.net             | Quobyte             |
-FES      | s3.fes.cloud.syseleven.net             | Quobyte             |
+FES      | s3.fes.cloud.syseleven.net             | Quobyte (eol 2025-06-15)  |
 FES      | objectstorage.fes.cloud.syseleven.net  | Ceph                |
 
 !!!! **Deprecated URL**
 !!!! For historical reasons 's3.cloud.syseleven.net' redirects to 's3.cbk.cloud.syseleven.net'.
 !!!! We recommend to always use a region specific URL like in the table above.
+
+!! s3.fes.cloud.syseleven.net will be end-of-life on 2025-06-15. We recommend to use `objectstorage.fes.cloud.syseleven.net instead. For existing object data refer to our [migration howto](../../03.Howtos/16.migrate-quobyte-to-ceph/docs.en.md).
 
 ## Credentials
 
@@ -119,10 +121,10 @@ host_base = s3.dbl.cloud.syseleven.net
 host_bucket = %(bucket).s3.dbl.cloud.syseleven.net
 #website_endpoint = https://%(bucket)s.s3.dbl.cloud.syseleven.net/%(location)s/
 website_endpoint = https://s3.dbl.cloud.syseleven.net/%(bucket)s/%(location)s/
-#host_base = s3.fes.cloud.syseleven.net
-#host_bucket = %(bucket).s3.fes.cloud.syseleven.net
-#website_endpoint = https://s3.fes.cloud.syseleven.net/%(bucket)s/%(location)s/
-#website_endpoint = https://%(bucket)s.s3.fes.cloud.syseleven.net/%(location)s/
+#host_base = objectstorage.fes.cloud.syseleven.net
+#host_bucket = %(bucket).objectstorage.fes.cloud.syseleven.net
+#website_endpoint = https://objectstorage.fes.cloud.syseleven.net/%(bucket)s/%(location)s/
+#website_endpoint = https://%(bucket)s.objectstorage.fes.cloud.syseleven.net/%(location)s/
 ```
 
 Next, create an S3 Bucket.


### PR DESCRIPTION
documents [os-21032](https://youtrack.syseleven.net/issue/os-21032) USER STORY: Charly wants to use Ceph as default volume type in FES